### PR TITLE
fix(heic): bump version for ios18 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM amazonlinux:2
 
 # Install OS packages...
-RUN yum install -y git gcc gcc-c++ cpp cpio make cmake automake autoconf chkconfig clang clang-libs dos2unix zlib zlib-devel zip unzip tar perl libxml2 bzip2 bzip2-libs xz xz-libs pkgconfig libtool
+RUN yum install -y git gcc gcc-c++ cpp cpio make cmake3 automake autoconf chkconfig clang clang-libs dos2unix zlib zlib-devel zip unzip tar perl libxml2 bzip2 bzip2-libs xz xz-libs pkgconfig libtool
 
 ADD build /root/build
 

--- a/build/build_imagemagick.sh
+++ b/build/build_imagemagick.sh
@@ -2,7 +2,7 @@
 set -e
 
 cd /root
-curl https://github.com/ImageMagick/ImageMagick/archive/7.0.8-45.tar.gz -L -o tmp-imagemagick.tar.gz
+curl https://github.com/ImageMagick/ImageMagick/archive/7.1.1-39.tar.gz -L -o tmp-imagemagick.tar.gz
 tar xf tmp-imagemagick.tar.gz
 cd ImageMagick*
 

--- a/build/build_lcms.sh
+++ b/build/build_lcms.sh
@@ -2,7 +2,7 @@
 set -e
 
 cd /root
-curl https://github.com/mm2/Little-CMS/releases/download/lcms2.12/lcms2-2.12.tar.gz -L -o tmp-lcms2.tar.gz
+curl https://github.com/mm2/Little-CMS/releases/download/lcms2.16/lcms2-2.16.tar.gz -L -o tmp-lcms2.tar.gz
 tar xf tmp-lcms2.tar.gz
 cd lcms2*
 

--- a/build/build_libde265.sh
+++ b/build/build_libde265.sh
@@ -2,7 +2,7 @@
 set -e
 
 cd /root
-curl https://github.com/strukturag/libde265/releases/download/v1.0.8/libde265-1.0.8.tar.gz -L -o tmp-libde265
+curl https://github.com/strukturag/libde265/releases/download/v1.0.15/libde265-1.0.15.tar.gz -L -o tmp-libde265
 tar xf tmp-libde265
 cd libde265*
 

--- a/build/build_libheif.sh
+++ b/build/build_libheif.sh
@@ -2,20 +2,29 @@
 set -e
 
 cd /root
-curl https://github.com/strukturag/libheif/releases/download/v1.12.0/libheif-1.12.0.tar.gz -L -o tmp-libheif.tar.gz
+
+curl -L -o tmp-libheif.tar.gz https://github.com/strukturag/libheif/releases/download/v1.18.2/libheif-1.18.2.tar.gz
 tar xf tmp-libheif.tar.gz
 cd libheif*
 
-sh autogen.sh
+mkdir -p build
+cd build
 
 PKG_CONFIG_PATH=/root/build/cache/lib/pkgconfig \
-  ./configure \
-    CPPFLAGS=-I/root/build/cache/include \
-    LDFLAGS=-L/root/build/cache/lib \
-    --disable-dependency-tracking \
-    --disable-shared \
-    --enable-static \
-    --prefix=/root/build/cache
+cmake3 .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/root/build/cache \
+    -DENABLE_PLUGIN_LOADING=OFF \
+    -DWITH_LIBDE265=ON \
+    -DWITH_X265=ON \
+    -DWITH_AOM_DECODER=ON \
+    -DWITH_AOM_ENCODER=ON \
+    -DWITH_RAV1E=OFF \
+    -DWITH_DAV1D=OFF \
+    -DWITH_SVTAV1=OFF \
+    -DWITH_OPENJPEG_DECODER=OFF \
+    -DWITH_OPENJPEG_ENCODER=OFF \
+    -DBUILD_SHARED_LIBS=OFF
 
-make
+make -j$(nproc)
 make install

--- a/build/build_libopenjp2.sh
+++ b/build/build_libopenjp2.sh
@@ -2,7 +2,7 @@
 set -e
 
 cd /root
-curl https://github.com/uclouvain/openjpeg/archive/v2.4.0.tar.gz -L -o tmp-libopenjp2.tar.gz
+curl https://github.com/uclouvain/openjpeg/archive/v2.5.2.tar.gz -L -o tmp-libopenjp2.tar.gz
 tar xf tmp-libopenjp2.tar.gz
 cd openjpeg*
 
@@ -10,7 +10,7 @@ mkdir -p build
 cd build
 
 PKG_CONFIG_PATH=/root/build/cache/lib/pkgconfig \
-  cmake .. \
+  cmake3 .. \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/root/build/cache \
     -DBUILD_SHARED_LIBS:bool=off \

--- a/build/build_libpng.sh
+++ b/build/build_libpng.sh
@@ -2,7 +2,7 @@
 set -e
 
 cd /root
-curl http://prdownloads.sourceforge.net/libpng/libpng-1.6.37.tar.xz -L -o tmp-libpng.tar.xz
+curl http://prdownloads.sourceforge.net/libpng/libpng-1.6.44.tar.xz -L -o tmp-libpng.tar.xz
 tar xf tmp-libpng.tar.xz
 cd libpng*
 

--- a/build/build_libtiff.sh
+++ b/build/build_libtiff.sh
@@ -2,7 +2,7 @@
 set -e
 
 cd /root
-curl http://download.osgeo.org/libtiff/tiff-4.3.0.tar.gz -L -o tmp-libtiff.tar.gz
+curl http://download.osgeo.org/libtiff/tiff-4.7.0.tar.gz -L -o tmp-libtiff.tar.gz
 tar xf tmp-libtiff.tar.gz
 cd tiff*
 

--- a/build/build_libwebp.sh
+++ b/build/build_libwebp.sh
@@ -2,7 +2,7 @@
 set -e
 
 cd /root
-curl https://github.com/webmproject/libwebp/archive/v1.2.1.tar.gz -L -o tmp-libwebp.tar.gz
+curl https://github.com/webmproject/libwebp/archive/v1.4.0.tar.gz -L -o tmp-libwebp.tar.gz
 tar xf tmp-libwebp.tar.gz
 cd libwebp*
 


### PR DESCRIPTION
Had to bump libheif version to properly convert IOS18 HEIC files https://github.com/ImageMagick/ImageMagick/discussions/7426e

This required some minor changes to the build as they no use autogen.sh and require cmake 3. Also bumped the rest of the versions while I was at it.